### PR TITLE
disable fields in panel when they are disabled

### DIFF
--- a/color.php
+++ b/color.php
@@ -40,6 +40,7 @@ class ColorField extends InputField{
     $color->attr(array(
       'name'         => $this->name(),
       'id'           => $this->id(),
+      'disabled'     => $this->disabled(),
       'type'           =>"text",
       'data-defaultvalue' => $value,
       'value'    => $value


### PR DESCRIPTION
this should solve https://github.com/ian-cox/Kirby-Color-Picker/issues/9
and also solve an issue related to using this plugin with `translate: false`
