### PR TITLE
add field-icon to js

### DIFF
--- a/assets/js/color.js
+++ b/assets/js/color.js
@@ -197,6 +197,7 @@
           .prop('size', size)
           .wrap(minicolors)
           .after(
+            '<div class="field-icon"><i class="icon fa fa-paint-brush"></i></div>' +
             '<div class="minicolors-panel minicolors-slider-' + settings.control + '">' +
             '<div class="minicolors-slider minicolors-sprite">' +
             '<div class="minicolors-picker"></div>' +


### PR DESCRIPTION
I noticed on using this time saving plugin that the icon was appearing in the panel alongside the field. Traipsing through the JS I discovered that the markup simply wasn't included. So I added it. One simple line added, now it appears just like the GIF in the readme.